### PR TITLE
use Issue labels to filter Issues and Milestones

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: ghqc.app
 Title: Create QC Checklists in Github Issues
-Version: 0.1.9
+Version: 0.1.10
 Authors@R: c(
     person("Jenna", "Johnson", email = "jenna@a2-ai.com", role = c("aut", "cre")),
     person("Anne", "Zheng", email = "anne@a2-ai.com", role = c("aut")),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+# ghqc.app 0.1.10
+
+- Adds "ghqc" label to all GitHub Issues created by ghqc. Only Issues with this label, and the Milestones containing them, will be viewable/selectable in the apps. This change is NOT backward compatible with Issues/Milestones created in previous versions
+
 # ghqc.app 0.1.9
 
 - Clarifies language in Warning and Error modals for all three apps

--- a/R/get_org_attributes.R
+++ b/R/get_org_attributes.R
@@ -394,8 +394,7 @@ get_all_issues_in_milestone <- function(owner, repo, milestone_name) {
     # next page
     page <- page + 1
   }
-
-  browser()
+  
   issues <- get_only_ghqc_issues(c(open_issues, closed_issues))
   info(.le$logger, glue::glue("Retrieved {length(issues)} ghqc Issue(s) from Milestone: {milestone_name}"))
   return(issues)

--- a/R/get_org_attributes.R
+++ b/R/get_org_attributes.R
@@ -334,7 +334,7 @@ get_all_issues_in_repo <- function(owner, repo) {
 
 get_only_ghqc_issues <- function(issues) {
   labels <- sapply(issues, function(x) x$labels)
-  issues[sapply(labels, function(x) "ghqc" %in% sapply(x, function(y) y$name))]
+  issues[sapply(labels, function(x) "ghqc" %in% sapply(x, function(y) unlist(y)["name"]))]
 }
 
 # sort by open/closed

--- a/R/get_org_attributes.R
+++ b/R/get_org_attributes.R
@@ -36,7 +36,7 @@ filter_for_non_empty_milestones <- function(milestones) {
 }
 
 filter_for_ghqc_milestones <- function(owner, repo, milestones) {
-  labels <- sapply(milestones, function(x) gh::gh("GET /repos/:owner/:repo/milestones/:milestone_number/labels", owner = owner, repo = repo, milestone_number = x$number))
+  labels <- sapply(milestones, function(x) gh::gh("GET /repos/:owner/:repo/milestones/:milestone_number/labels", owner = owner, repo = repo, milestone_number = x$number), .api_url = .le$github_api_url)
   milestones[sapply(labels, function(x) "ghqc" %in% sapply(x, function(y) y$name))]
 }
 

--- a/R/get_org_attributes.R
+++ b/R/get_org_attributes.R
@@ -36,8 +36,9 @@ filter_for_non_empty_milestones <- function(milestones) {
 }
 
 filter_for_ghqc_milestones <- function(owner, repo, milestones) {
+  if (length(milestones) == 0) return(milestones)
   labels <- sapply(milestones, function(x) gh::gh("GET /repos/:owner/:repo/milestones/:milestone_number/labels", owner = owner, repo = repo, milestone_number = x$number, .api_url = .le$github_api_url))
-  milestones[sapply(labels, function(x) "ghqc" %in% sapply(x, function(y) y$name))]
+  milestones[sapply(labels, function(x) "ghqc" %in% sapply(x, function(y) y))]
 }
 
 #' @importFrom log4r warn error info debug
@@ -333,7 +334,9 @@ get_all_issues_in_repo <- function(owner, repo) {
 }
 
 get_only_ghqc_issues <- function(issues) {
+  if (length(issues) == 0) return(issues)
   labels <- sapply(issues, function(x) x$labels)
+  if (length(labels) == 0) return(c(list(), list()))
   issues[sapply(labels, function(x) "ghqc" %in% sapply(x, function(y) y))]
 }
 

--- a/R/get_org_attributes.R
+++ b/R/get_org_attributes.R
@@ -36,7 +36,7 @@ filter_for_non_empty_milestones <- function(milestones) {
 }
 
 filter_for_ghqc_milestones <- function(owner, repo, milestones) {
-  labels <- sapply(milestones, function(x) gh::gh("GET /repos/:owner/:repo/milestones/:milestone_number/labels", owner = owner, repo = repo, milestone_number = x$number), .api_url = .le$github_api_url)
+  labels <- sapply(milestones, function(x) gh::gh("GET /repos/:owner/:repo/milestones/:milestone_number/labels", owner = owner, repo = repo, milestone_number = x$number, .api_url = .le$github_api_url))
   milestones[sapply(labels, function(x) "ghqc" %in% sapply(x, function(y) y$name))]
 }
 

--- a/R/get_org_attributes.R
+++ b/R/get_org_attributes.R
@@ -334,7 +334,7 @@ get_all_issues_in_repo <- function(owner, repo) {
 
 get_only_ghqc_issues <- function(issues) {
   labels <- sapply(issues, function(x) x$labels)
-  issues[sapply(labels, function(x) "ghqc" %in% sapply(x, function(y) unlist(y)["name"]))]
+  issues[sapply(labels, function(x) "ghqc" %in% sapply(x, function(y) y))]
 }
 
 # sort by open/closed
@@ -395,6 +395,7 @@ get_all_issues_in_milestone <- function(owner, repo, milestone_name) {
     page <- page + 1
   }
 
+  browser()
   issues <- get_only_ghqc_issues(c(open_issues, closed_issues))
   info(.le$logger, glue::glue("Retrieved {length(issues)} ghqc Issue(s) from Milestone: {milestone_name}"))
   return(issues)

--- a/R/get_org_attributes.R
+++ b/R/get_org_attributes.R
@@ -35,13 +35,20 @@ filter_for_non_empty_milestones <- function(milestones) {
   return(non_empty_milestones)
 }
 
+filter_for_ghqc_milestones <- function(owner, repo, milestones) {
+  labels <- sapply(milestones, function(x) gh::gh("GET /repos/:owner/:repo/milestones/:milestone_number/labels", owner = owner, repo = repo, milestone_number = x$number))
+  milestones[sapply(labels, function(x) "ghqc" %in% sapply(x, function(y) y$name))]
+}
+
 #' @importFrom log4r warn error info debug
 get_open_milestone_objects <- function(owner, repo) {
   debug(.le$logger, glue::glue("Retrieving open Milestone(s) in organization {owner}, repo {repo}..."))
 
   milestones <- gh::gh("GET /repos/:owner/:repo/milestones", .api_url = .le$github_api_url, owner = owner, repo = repo, state = "open", .limit = Inf)
-  info(.le$logger, glue::glue("Retrieved {length(milestones)} open Milestone(s) in repo {repo}"))
-  non_empty_milestones <- filter_for_non_empty_milestones(milestones)
+  debug(.le$logger, glue::glue("Retrieved {length(milestones)} open Milestone(s) in repo {repo}"))
+  ghqc_milestones <- filter_for_ghqc_milestones(owner, repo, milestones)
+  info(.le$logger, glue::glue("Retrieved {length(ghqc_milestones)} open ghqc Milestone(s) in repo {repo}"))
+  non_empty_milestones <- filter_for_non_empty_milestones(ghqc_milestones)
 }
 
 #' @importFrom log4r warn error info debug
@@ -49,8 +56,10 @@ get_closed_milestone_objects <- function(owner, repo) {
   debug(.le$logger, glue::glue("Retrieving closed Milestone(s) in organization {owner}, repo {repo}..."))
 
   milestones <- gh::gh("GET /repos/:owner/:repo/milestones", .api_url = .le$github_api_url, owner = owner, repo = repo, state = "closed", .limit = Inf)
-  info(.le$logger, glue::glue("Retrieved {length(milestones)} closed Milestone(s) in repo {repo}"))
-  non_empty_milestones <- filter_for_non_empty_milestones(milestones)
+  debug(.le$logger, glue::glue("Retrieved {length(milestones)} closed Milestone(s) in repo {repo}"))
+  ghqc_milestones <- filter_for_ghqc_milestones(owner, repo, milestones)
+  info(.le$logger, glue::glue("Retrieved {length(ghqc_milestones)} closed ghqc Milestone(s) in repo {repo}"))
+  non_empty_milestones <- filter_for_non_empty_milestones(ghqc_milestones)
 }
 
 #' @importFrom log4r warn error info debug
@@ -86,8 +95,10 @@ list_milestones <- function(org, repo) {
   debug(.le$logger, glue::glue("Retrieving Milestone(s) in organization {org}, repo {repo}..."))
   milestones <- get_all_milestone_objects(org, repo)
   info(.le$logger, glue::glue("Retrieved {length(milestones)} total Milestone(s) in repo {repo}"))
-  non_empty_milestones <- filter_for_non_empty_milestones(milestones)
-  info(.le$logger, glue::glue("Retrieved {length(non_empty_milestones)} non-empty Milestone(s) in repo {repo}"))
+  ghqc_milestones <- filter_for_ghqc_milestones(org, repo, milestones)
+  info(.le$logger, glue::glue("Retrieved {length(ghqc_milestones)} ghqc Milestone(s) in repo {repo}"))
+  non_empty_milestones <- filter_for_non_empty_milestones(ghqc_milestones)
+  info(.le$logger, glue::glue("Retrieved {length(non_empty_milestones)} non-empty ghqc Milestone(s) in repo {repo}"))
   res <- purrr::map_chr(non_empty_milestones, "title")
   return(res)
 }
@@ -314,11 +325,16 @@ get_all_issues_in_repo <- function(owner, repo) {
     page <- page + 1
   }
 
-  issues <- c(open_issues, closed_issues)
+  issues <- get_only_ghqc_issues(c(open_issues, closed_issues))
   num_issues <- length(issues)
   info(.le$logger, glue::glue("Retrieved {num_issues} Issue(s) from repo: {repo}"))
   return(issues)
 
+}
+
+get_only_ghqc_issues <- function(issues) {
+  labels <- sapply(issues, function(x) x$labels)
+  issues[sapply(labels, function(x) "ghqc" %in% sapply(x, function(y) y$name))]
 }
 
 # sort by open/closed
@@ -379,8 +395,8 @@ get_all_issues_in_milestone <- function(owner, repo, milestone_name) {
     page <- page + 1
   }
 
-  issues <- c(open_issues, closed_issues)
-  info(.le$logger, glue::glue("Retrieved {length(issues)} Issue(s) from Milestone: {milestone_name}"))
+  issues <- get_only_ghqc_issues(c(open_issues, closed_issues))
+  info(.le$logger, glue::glue("Retrieved {length(issues)} ghqc Issue(s) from Milestone: {milestone_name}"))
   return(issues)
 }
 

--- a/R/multi_issue.R
+++ b/R/multi_issue.R
@@ -23,7 +23,8 @@ create_issue <- function(file, issue_params) {
   label_params <- list(owner = issue_params$owner,
                        repo = issue_params$repo,
                        issue_number = issue$number,
-                       labels = array("ghqc"))
+                       labels = array("ghqc"),
+                       .api_url = .le$github_api_url)
   label <- do.call(gh::gh, c("POST /repos/{owner}/{repo}/issues/{issue_number}/labels", label_params))
   debug(.le$logger, glue::glue("Label 'ghqc' added to {issue_params$title}"))
 
@@ -83,7 +84,8 @@ create_issues <- function(data) {
 ghqc_label_exists <- function(data) {
   labels <- do.call(gh::gh, c("GET /repos/{owner}/{repo}/labels",
                               list(owner = data$owner,
-                                   repo = data$repo
+                                   repo = data$repo,
+                                   .api_url = .le$github_api_url
                                    )))
   "ghqc" %in% sapply(labels, function(x) x$name)
 }
@@ -95,7 +97,8 @@ create_ghqc_label <- function(data) {
     repo = data$repo,
     name = "ghqc",
     color = "FFCB05",
-    description = "Issue created by the ghqc package"
+    description = "Issue created by the ghqc package",
+    .api_url = .le$github_api_url
   )
   do.call(gh::gh, c("POST /repos/{owner}/{repo}/labels", issue_params))
 }

--- a/R/multi_issue.R
+++ b/R/multi_issue.R
@@ -79,6 +79,7 @@ create_issues <- function(data) {
   info(.le$logger, glue::glue("Created checklist(s) for file(s): {file_names}"))
 } # create_issues
 
+#' @importFrom gh gh
 ghqc_label_exists <- function(data) {
   labels <- do.call(gh::gh, c("GET /repos/{owner}/{repo}/labels",
                               list(owner = data$owner,
@@ -87,6 +88,7 @@ ghqc_label_exists <- function(data) {
   "ghqc" %in% sapply(labels, function(x) x$name)
 }
 
+#' @importFrom gh gh
 create_ghqc_label <- function(data) {
   issue_params <- list(
     owner = data$owner,


### PR DESCRIPTION
Create a "ghqc" label that gets attached to all Issues created by the ghqc Shiny apps. This allows for the continued use of Issues, Milestones, and pull requests not related to the QC process, and not have it "pollute" the ghqc interface.