### PR TITLE
fix resolve comment hash bug

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: ghqc.app
 Title: Create QC Checklists in Github Issues
-Version: 0.4.0
+Version: 0.4.1
 Authors@R: c(
     person("Jenna", "Johnson", email = "jenna@a2-ai.com", role = c("aut", "cre")),
     person("Anne", "Zheng", email = "anne@a2-ai.com", role = c("aut")),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+# ghqc.app 0.4.1
+
+- fixes bug in md5 hashes in resolve comment metadata to make hashes correct
+
 # ghqc.app 0.4.0
 
 - fixes large logo bug

--- a/R/qc_fix.R
+++ b/R/qc_fix.R
@@ -46,23 +46,16 @@ create_message_body <- function(message) {
   else glue::glue("{message}\n\n\n")
 }
 
-get_script_hash <- function(script) {
-  collapsed_script <- glue::glue_collapse(script, "\n")
-  digest::digest(collapsed_script, algo = "md5")
-}
 
 create_comment_metadata_body <- function(file_path,
                                  reference_commit,
-                                 reference_script,
+                                 reference_hash,
                                  comparator_commit,
-                                 comparator_script,
+                                 comparator_hash,
                                  owner,
                                  repo,
                                  remote_url) {
 
-  # get script hashes
-  reference_script_hash <- get_script_hash(reference_script)
-  comparator_script_hash <- get_script_hash(comparator_script)
 
   ref_url <- get_file_contents_url(file_path = file_path,
                                    git_sha = reference_commit,
@@ -78,10 +71,10 @@ create_comment_metadata_body <- function(file_path,
 
   glue::glue("## Metadata\n",
              "* current commit: {comparator_commit}\n",
-             "* current script md5 checksum: {comparator_script_hash}\n",
+             "* current script md5 checksum: {comparator_hash}\n",
              "* file contents at current commit: {comp_url}\n&nbsp;\n",
              "* previous commit: {reference_commit}\n",
-             "* previous script md5 checksum: {reference_script_hash}\n",
+             "* previous script md5 checksum: {reference_hash}\n",
              "* file contents at previous commit: {ref_url}\n\n\n")
 }
 
@@ -140,6 +133,9 @@ create_comment_body <- function(owner,
   comparator_script <- script_contents$comparator_script
   debug(.le$logger, glue::glue("Got script contents"))
 
+  reference_hash <- script_contents$hash_at_reference
+  comparator_hash <- script_contents$hash_at_comparator
+
   debug(.le$logger, glue::glue("Getting file difference body..."))
   diff_body <- create_diff_body(diff = diff,
                            reference_commit = reference_commit,
@@ -151,9 +147,9 @@ create_comment_body <- function(owner,
   debug(.le$logger, glue::glue("Getting metadata body..."))
   metadata_body <- create_comment_metadata_body(file_path = issue$title,
                                         reference_commit = reference_commit,
-                                        reference_script = reference_script,
+                                        reference_hash = reference_hash,
                                         comparator_commit = comparator_commit,
-                                        comparator_script = comparator_script,
+                                        comparator_hash = comparator_hash,
                                         owner = owner,
                                         repo = repo,
                                         remote_url = remote_url)

--- a/R/qc_fix_helper.R
+++ b/R/qc_fix_helper.R
@@ -150,7 +150,14 @@ get_script_contents <- function(file_path, reference, comparator) {
   reference_script <- suppressWarnings(readLines(file_at_reference))
   comparator_script <- suppressWarnings(readLines(file_at_comparator))
 
-  list(reference_script = reference_script, comparator_script = comparator_script)
+  hash_at_reference <- digest::digest(file = file_at_reference, algo = "md5")
+  hash_at_comparator <- digest::digest(file = file_at_comparator, algo = "md5")
+
+  list(reference_script = reference_script,
+       comparator_script = comparator_script,
+       hash_at_reference = hash_at_reference,
+       hash_at_comparator = hash_at_comparator
+       )
 }
 
 format_diff <- function(reference_script, comparator_script) {


### PR DESCRIPTION
The file hash in resolve comments were buggy. Don't know how I didn't catch this eariler. The proof is in any first resolve comment.
For example here: https://github.com/A2-ai/test_0.4.0/issues/3
The original hash doesn't match what the comment claims the original hash to be. 
The reason was a pretty convoluted way of getting the hash - frankensteining the contents then getting the hash - very error prone.

fix shown here: 

![Screenshot 2025-01-08 at 10 14 56 AM](https://github.com/user-attachments/assets/51d58c44-dc09-4f6b-9904-753204514db1)
