### PR TITLE
Allowing multi-formatting in metadata section

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: ghqc.app
 Title: Create QC Checklists in Github Issues
-Version: 0.4.10
+Version: 0.4.11
 Authors@R: c(
     person("Jenna", "Johnson", email = "jenna@a2-ai.com", role = c("aut", "cre")),
     person("Anne", "Zheng", email = "anne@a2-ai.com", role = c("aut")),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+# ghqc.app 0.4.11
+
+- allows metadata bullet parsing to recognize both `*` and `-` characters. 
+
 # ghqc.app 0.4.10
 
 - fixes error in Associate Relevant Files modal pop-up

--- a/R/scrape_helper.R
+++ b/R/scrape_helper.R
@@ -151,8 +151,8 @@ get_metadata <- function(body) {
   metadata <- list()
 
   for (line in metadata_lines) {
-    if (stringr::str_detect(line, "^\\*")) {
-      key_value <- stringr::str_match(line, "\\*\\s*(.*?):\\s*(.*)")[2:3]
+    if (stringr::str_detect(line, "^[*-]")) {
+      key_value <- stringr::str_match(line, "[*-]\\s*(.*?):\\s*(.*)")[2:3]
       metadata[[key_value[1]]] <- key_value[2]
     }
   }


### PR DESCRIPTION
During use, someone edited there Metadata section dramatically and used `-` instead of `*` for the bullet points. This is actually somewhat intuitive from the end user POV since the checklist items start with a `-`. Therefore, allowing either formatting