### PR TITLE
fixes bug in which the api url isn't included for the QC approved com…

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: ghqc.app
 Title: Create QC Checklists in Github Issues
-Version: 0.6.4
+Version: 0.6.5
 Authors@R: c(
     person("Jenna", "Johnson", email = "jenna@a2-ai.com", role = c("aut", "cre")),
     person("Anne", "Zheng", email = "anne@a2-ai.com", role = c("aut")),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+# ghqc.app 0.6.5
+
+- fixes bug in `ghqc_status_app()`in which the api url isn't included for the QC approved comment edit api call (works for github which is the default, but not GHE)
+
 # ghqc.app 0.6.4
 
 - fixes bug in `ghqc_notify_app()` in which not all ghqc Issues were listed in dropdown due to change in function filtering behavior now that the QC branch is also a label added to ghqc Issues.

--- a/R/qc_fix.R
+++ b/R/qc_fix.R
@@ -276,6 +276,7 @@ edit_approve_comment <- function(approve_comment) {
     "PATCH /repos/:org/:repo/issues/comments/:comment_id",
     org = .le$org,
     repo = .le$repo,
+    .api_url = .le$github_api_url,
     comment_id = comment_id,
     body = new_comment_body
   )


### PR DESCRIPTION
…ment edit api call (works for github which is the default, but not GHE)